### PR TITLE
Use {{ secrets.DOCKER_USER }} intead of a hardcoded username

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -233,9 +233,9 @@ jobs:
 
       - name: Login to Docker Hub
         env:
-          DOCKER_USER: meedamian
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
         run: |
-          echo "Logging in as ${DOCKER_USER}…"
+          echo "Logging in as ${DOCKER_USER}"
           echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u="$DOCKER_USER" --password-stdin
 
       - name: Push all images


### PR DESCRIPTION
Use {{ secrets.DOCKER_USER }} instead of a hardcoded username so any forked projects can build their own